### PR TITLE
Add "makeWithdrawLpTokensInvitation" function to stopLoss and respective tests

### DIFF
--- a/contract/src/assertionHelper.js
+++ b/contract/src/assertionHelper.js
@@ -42,7 +42,7 @@ export const assertExecutionMode = (ammPublicFacet, devPriceAuthority) => {
     X`You can either run this contract with a ammPublicFacet for prod mode or with a priceAuthority for dev mode`);
 };
 
-export const assertAllocationStatePhase = async (notifier, phase) => {
-  const {value: allocationState} = await E(notifier).getUpdateSince();
-  assert(allocationState.phase === phase, X`AllocationState phase should be: ${phase}`);
+export const assertAllocationStatePhase = (phaseSnapshot, phase) => {
+  console.log("LOG = ", phaseSnapshot)
+  assert(phaseSnapshot === phase, X`AllocationState phase should be: ${phase}`);
 };

--- a/contract/src/stopLoss.js
+++ b/contract/src/stopLoss.js
@@ -52,9 +52,12 @@ const start = async (zcf) => {
 
   const { updater, notifier } = makeNotifierKit(getStateSnapshot(ALLOCATION_PHASE.IDLE));
 
+  let phaseSnapshot = ALLOCATION_PHASE.IDLE;
+
   const updateAllocationState = (allocationPhase) => {
     const allocationState = getStateSnapshot(allocationPhase);
     updater.updateState(allocationState);
+    phaseSnapshot = allocationPhase;
   }
 
   assertBoundaryShape(boundaries, centralBrand, secondaryBrand);
@@ -112,12 +115,12 @@ const start = async (zcf) => {
   }); // Notify user
 
   const makeLockLPTokensInvitation = () => {
-    const lockLPTokens = async (creatorSeat) => {
+    const lockLPTokens = (creatorSeat) => {
       assertProposalShape(creatorSeat, {
         give: { Liquidity: null },
       });
 
-      await assertAllocationStatePhase(notifier, ALLOCATION_PHASE.SCHEDULED);
+      assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.SCHEDULED);
 
       const {
         give: { Liquidity: lpTokenAmount },
@@ -178,14 +181,14 @@ const start = async (zcf) => {
   };
 
   const makeWithdrawLiquidityInvitation = () => {
-    const withdrawLiquidity = async (creatorSeat) => {
+    const withdrawLiquidity = (creatorSeat) => {
       assertProposalShape(creatorSeat, {
         want: {
           Central: null,
           Secondary: null,
         },
       });
-      await assertAllocationStatePhase(notifier, ALLOCATION_PHASE.REMOVED);
+      assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.REMOVED);
 
       const centralAmountAllocated = stopLossSeat.getAmountAllocated(
         'Central',
@@ -218,12 +221,12 @@ const start = async (zcf) => {
   };
 
   const makeWithdrawLpTokensInvitation = () => {
-    const withdrawLpTokens = async (creatorSeat) => {
+    const withdrawLpTokens = (creatorSeat) => {
       assertProposalShape(creatorSeat, {
         want: {Liquidity: null},
       });
 
-      await assertAllocationStatePhase(notifier, ALLOCATION_PHASE.ACTIVE);
+      assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.ACTIVE);
 
       const lpTokenAmountAllocated = stopLossSeat.getAmountAllocated(
         'Liquidity',

--- a/contract/test/test-stopLoss.js
+++ b/contract/test/test-stopLoss.js
@@ -1603,12 +1603,17 @@ test('Test withdraw Liquidity', async (t) => {
     withdrawProposal,
   );
 
+  const [withdrawLiquidityMessage, withdrawSeatAllocation] = await Promise.all([
+    E(withdrawSeat).getOfferResult(),
+    E(withdrawSeat).getCurrentAllocation(),
+  ]); 
 
-
-  // Check Offer result
-  const withdrawLiquidityMessage = await E(withdrawSeat).getOfferResult();
+  // Check Offer result and creator seat allocation
   t.deepEqual(withdrawLiquidityMessage, 'Liquidity withdraw to creator seat');
+  t.deepEqual(withdrawSeatAllocation.Central, centralInUnit(30n));
+  t.deepEqual(withdrawSeatAllocation.Secondary, secondaryInUnit(60n))
 
+ 
   const [withdrawCentralBalance, withdrawSecondaryBalance, withdrawLiquidityBalance,  { value: notificationAfterWithdraw }] = await Promise.all([
     E(publicFacet).getBalanceByBrand('Central', centralIssuer),
     E(publicFacet).getBalanceByBrand('Secondary', secondaryIssuer),
@@ -1622,10 +1627,6 @@ test('Test withdraw Liquidity', async (t) => {
     t.deepEqual(notificationAfterWithdraw.liquidityBalance.central, withdrawCentralBalance);
     t.deepEqual(notificationAfterWithdraw.liquidityBalance.secondary, withdrawSecondaryBalance);
 
-  // Check creator seat allocation
-  const withdrawSeatAllocation = await E(withdrawSeat).getCurrentAllocation();
-  t.deepEqual(withdrawSeatAllocation.Central, centralInUnit(30n));
-  t.deepEqual(withdrawSeatAllocation.Secondary, secondaryInUnit(60n))
 });
 
 test('Test withdraw LP Tokens while having tokens locked', async (t) => {
@@ -1733,8 +1734,14 @@ test('Test withdraw LP Tokens while having tokens locked', async (t) => {
     withdrawProposal,
   );
 
-  const withdrawLpTokenMessage = await E(withdrawLpSeat).getOfferResult();
+  const [withdrawLpTokenMessage, withdrawLpSeatAllocation] = await Promise.all([
+    E(withdrawLpSeat).getOfferResult(),
+    E(withdrawLpSeat).getCurrentAllocation(),
+  ]); 
+
+  // Check Offer result and creator seat allocation
   t.deepEqual(withdrawLpTokenMessage, 'LP Tokens withdraw to creator seat');
+  t.deepEqual(withdrawLpSeatAllocation.Liquidity.value, 3000000000n);
 
   const [ withdrawLiquidityBalance,  { value: notificationAfterWithdraw }] = await Promise.all([
     E(publicFacet).getBalanceByBrand('Liquidity', lpTokenIssuer),
@@ -1745,8 +1752,8 @@ test('Test withdraw LP Tokens while having tokens locked', async (t) => {
   t.deepEqual(notificationAfterWithdraw.phase, ALLOCATION_PHASE.WITHDRAWN);
   t.deepEqual(notificationAfterWithdraw.lpBalance, withdrawLiquidityBalance);
 
-  // Check creator seat
-  const withdrawLpSeatAllocation = await E(withdrawLpSeat).getCurrentAllocation();
-  t.deepEqual(withdrawLpSeatAllocation.Liquidity.value, 3000000000n);
+
+
+
   
 });


### PR DESCRIPTION
The "makeWithdrawLpTokensInvitation" function allow the user to withdraw his LP tokens from the stopLoss seat.

The "assertAllocationStatePhase" was created and used to verify the current AllocationStage phase before executing each of the following operation:

- makeLockLPTokensInvitation
- makeWithdrawLiquidityInvitation
- makeWithdrawLpTokensInvitation

The "assertAllocationStatePhase" was updated to receive a global variable with current phase instead of using notifier to reduce time by removing await for promises.

The ava tests in the test-stopLoss.js are working properly.
