### PR TITLE
Add "Test lock additional LP Tokens to contract"

### DIFF
--- a/contract/src/assertionHelper.js
+++ b/contract/src/assertionHelper.js
@@ -43,6 +43,5 @@ export const assertExecutionMode = (ammPublicFacet, devPriceAuthority) => {
 };
 
 export const assertAllocationStatePhase = (phaseSnapshot, phase) => {
-  console.log("LOG = ", phaseSnapshot)
   assert(phaseSnapshot === phase, X`AllocationState phase should be: ${phase}`);
 };

--- a/contract/src/stopLoss.js
+++ b/contract/src/stopLoss.js
@@ -52,6 +52,7 @@ const start = async (zcf) => {
 
   const { updater, notifier } = makeNotifierKit(getStateSnapshot(ALLOCATION_PHASE.IDLE));
 
+  // phaseSnapshot used for assertAllocationStatePhase
   let phaseSnapshot = ALLOCATION_PHASE.IDLE;
 
   const updateAllocationState = (allocationPhase) => {
@@ -120,7 +121,13 @@ const start = async (zcf) => {
         give: { Liquidity: null },
       });
 
-      assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.SCHEDULED);
+      //TODO: refractor the next condition
+      const lpBalance = getBalanceByBrand('Liquidity', lpTokenIssuer).value;
+      if (lpBalance === 0n) {
+        assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.SCHEDULED);
+      } else {
+        assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.ACTIVE);
+      }
 
       const {
         give: { Liquidity: lpTokenAmount },


### PR DESCRIPTION
The "Test lock additional LP Tokens to contract" simulated a user locking additional LP tokens from the same AMM pool to the contract.

The method used from stopLoss contract was the already implemented "makeLockLPTokensInvitation".

A condition was created for the "assertAllocationStatePhase" to verify the phase based on the amount of LP tokens previously locked, if were 0 or not.