### PR TITLE
Add "assertLockTokens" to the "makeLockLPTokensInvitation"

### DIFF
--- a/contract/src/assertionHelper.js
+++ b/contract/src/assertionHelper.js
@@ -2,6 +2,7 @@ import { assert, details as X } from '@agoric/assert';
 import { assertIsRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { E } from '@endo/far';
 import { makeTracer } from '@agoric/inter-protocol/src/makeTracer.js';
+import { ALLOCATION_PHASE } from './constants.js';
 
 const tracer = makeTracer('assertionHelper');
 
@@ -45,3 +46,17 @@ export const assertExecutionMode = (ammPublicFacet, devPriceAuthority) => {
 export const assertAllocationStatePhase = (phaseSnapshot, phase) => {
   assert(phaseSnapshot === phase, X`AllocationState phase should be: ${phase}`);
 };
+
+export const assertLockTokens = (phase) => {
+  const checkStatePhase = (phase) => {
+    switch (phase) {
+      case ALLOCATION_PHASE.SCHEDULED:
+      case ALLOCATION_PHASE.ACTIVE:
+        return true;
+      default:
+        return false;
+    }
+  };
+
+  assert(checkStatePhase(phase), X`The phase should be ACTIVE or SCHEDULED to lock tokens`);
+}

--- a/contract/src/stopLoss.js
+++ b/contract/src/stopLoss.js
@@ -8,7 +8,7 @@ import {
 import { Far, E } from '@endo/far';
 import { AmountMath } from '@agoric/ertp';
 import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
-import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase } from './assertionHelper.js';
+import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase, assertLockTokens } from './assertionHelper.js';
 import { makeBoundaryWatcher } from './boundaryWatcher.js';
 import { makeNotifierKit } from '@agoric/notifier';
 import { ALLOCATION_PHASE, BOUNDARY_WATCHER_STATUS } from './constants.js';
@@ -121,13 +121,7 @@ const start = async (zcf) => {
         give: { Liquidity: null },
       });
 
-      //TODO: refractor the next condition
-      const lpBalance = getBalanceByBrand('Liquidity', lpTokenIssuer).value;
-      if (lpBalance === 0n) {
-        assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.SCHEDULED);
-      } else {
-        assertAllocationStatePhase(phaseSnapshot, ALLOCATION_PHASE.ACTIVE);
-      }
+      assertLockTokens(phaseSnapshot);
 
       const {
         give: { Liquidity: lpTokenAmount },


### PR DESCRIPTION
An update was made, where the "assertLockTokens" exported from assertionHelper.js, is used on the "makeLockLPTokensInvitation", to verify that the current allocation phase is either SCHEDULED or ACTIVE.

Ava tests are working properly.