### PR TITLE
add "update-boundaries-outside-of-price-range" test

### DIFF
--- a/contract/src/assertionHelper.js
+++ b/contract/src/assertionHelper.js
@@ -47,7 +47,7 @@ export const assertAllocationStatePhase = (phaseSnapshot, phase) => {
   assert(phaseSnapshot === phase, X`AllocationState phase should be: ${phase}`);
 };
 
-export const assertLockTokens = (phase) => {
+export const assertScheduledOrActive = (phase) => {
   const checkStatePhase = (phase) => {
     switch (phase) {
       case ALLOCATION_PHASE.SCHEDULED:

--- a/contract/src/stopLoss.js
+++ b/contract/src/stopLoss.js
@@ -8,7 +8,7 @@ import {
 import { Far, E } from '@endo/far';
 import { AmountMath } from '@agoric/ertp';
 import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
-import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase, assertLockTokens } from './assertionHelper.js';
+import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase, assertScheduledOrActive } from './assertionHelper.js';
 import { makeBoundaryWatcher } from './boundaryWatcher.js';
 import { makeNotifierKit } from '@agoric/notifier';
 import { ALLOCATION_PHASE, BOUNDARY_WATCHER_STATUS } from './constants.js';
@@ -121,7 +121,7 @@ const start = async (zcf) => {
         give: { Liquidity: null },
       });
 
-      assertLockTokens(phaseSnapshot);
+      assertScheduledOrActive(phaseSnapshot);
 
       const {
         give: { Liquidity: lpTokenAmount },
@@ -255,6 +255,7 @@ const start = async (zcf) => {
   };
 
   const updateConfiguration = async boundaries => {
+    assertScheduledOrActive(phaseSnapshot);
     return await updateBoundaries(boundaries);
   };
 


### PR DESCRIPTION
The "update-boundaries-outside-of-price-range" test simulates a user update the boundaries using the "updateConfiguration" function to a new range outside of the current price.

This action will trigger the "removeLiquidity" function and the user assets will be removed from the AMM to the contract seat.

The "assertScheduledOrActive", (previously called "assertLockTokens") was included in the "updateConfiguration" function