### PR TITLE
Add "isPriceInsideInitialBoundaries" function and respective test and assertion

### DIFF
--- a/contract/src/assertionHelper.js
+++ b/contract/src/assertionHelper.js
@@ -3,6 +3,7 @@ import { assertIsRatio } from '@agoric/zoe/src/contractSupport/ratio.js';
 import { E } from '@endo/far';
 import { makeTracer } from '@agoric/inter-protocol/src/makeTracer.js';
 import { ALLOCATION_PHASE } from './constants.js';
+import { AmountMath } from '@agoric/ertp';
 
 const tracer = makeTracer('assertionHelper');
 
@@ -28,6 +29,13 @@ export const assertBoundaryShape = (boundaries, centralBrand, secondaryBrand) =>
   assert(lower.numerator.brand === secondaryBrand, X`Numerator of the lower ratio should be of the brand: ${secondaryBrand}`);
   assert(lower.denominator.brand === centralBrand, X`Denominator of the lower ratio should be of the brand: ${centralBrand}`);
 };
+
+export const assertInitialBoundariesRange = (boundaries, quoteAmountOut) => {
+  const { upper, lower } = boundaries;
+  
+  assert(AmountMath.isGTE(upper.numerator, quoteAmountOut), X`Upper boundary should be higher or equal to current price: ${quoteAmountOut.value}`)
+  assert(AmountMath.isGTE(quoteAmountOut, lower.numerator), X`Lower boundary should be lower or equal to current price: ${quoteAmountOut.value}`)
+}
 
 /**
  *

--- a/contract/src/stopLoss.js
+++ b/contract/src/stopLoss.js
@@ -8,7 +8,7 @@ import {
 import { Far, E } from '@endo/far';
 import { AmountMath } from '@agoric/ertp';
 import { offerTo } from '@agoric/zoe/src/contractSupport/index.js';
-import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase, assertScheduledOrActive } from './assertionHelper.js';
+import { assertBoundaryShape, assertExecutionMode, assertAllocationStatePhase, assertScheduledOrActive, assertInitialBoundariesRange } from './assertionHelper.js';
 import { makeBoundaryWatcher } from './boundaryWatcher.js';
 import { makeNotifierKit } from '@agoric/notifier';
 import { ALLOCATION_PHASE, BOUNDARY_WATCHER_STATUS } from './constants.js';
@@ -73,6 +73,8 @@ const start = async (zcf) => {
       fromCentralPriceAuthority = devPriceAuthority;
     }
 
+    await isPriceInsideInitialBoundaries(fromCentralPriceAuthority, boundaries, secondaryBrand);
+
     const boundaryWatcher = makeBoundaryWatcher({
       fromCentralPriceAuthority,
       boundaries,
@@ -84,6 +86,13 @@ const start = async (zcf) => {
 
     return boundaryWatcher;
   };
+
+  const isPriceInsideInitialBoundaries = async (fromCentralPriceAuthority, boundaries, secondaryBrand) => {
+    const amountIn = boundaries.lower.denominator;
+    const quote = await E(fromCentralPriceAuthority).quoteGiven(amountIn, secondaryBrand);
+    const quoteAmountOut = getAmountOut(quote);
+    assertInitialBoundariesRange(boundaries, quoteAmountOut)
+  }
 
   // Initiate listening
   const {


### PR DESCRIPTION
The "isPriceInsideInitialBoundaries" verifies if the initial boundaries, provided by the creator on the stopLoss terms, are out of range of the current pool price ratio.

The "isPriceInsideInitialBoundaries" is then invoked in the "init" function.

The ava tests in the test-stopLoss.js are working properly.